### PR TITLE
allow for empty before_ids and after_ids

### DIFF
--- a/nanogcg/gcg.py
+++ b/nanogcg/gcg.py
@@ -214,9 +214,9 @@ class GCG:
         target = " " + target if config.add_space_before_target else target
 
         # Tokenize everything that doesn't get optimized
-        before_ids = tokenizer([before_str], padding=False, return_tensors="pt")["input_ids"].to(model.device)
-        after_ids = tokenizer([after_str], add_special_tokens=False, return_tensors="pt")["input_ids"].to(model.device)
-        target_ids = tokenizer([target], add_special_tokens=False, return_tensors="pt")["input_ids"].to(model.device)
+        before_ids = tokenizer([before_str], padding=False, return_tensors="pt")["input_ids"].to(model.device).to(torch.int64)
+        after_ids = tokenizer([after_str], add_special_tokens=False, return_tensors="pt")["input_ids"].to(model.device).to(torch.int64)
+        target_ids = tokenizer([target], add_special_tokens=False, return_tensors="pt")["input_ids"].to(model.device).to(torch.int64)
 
         # Embed everything that doesn't get optimized
         embedding_layer = self.embedding_layer


### PR DESCRIPTION
Currently if the chat template does not have prefix/suffix text to add, the run will fail because torch defaults to float32 dtype for empty tensors, meaning that the embedding lookup in gcg.py:223 will cause an error. This is useful for models that do not have prefixes/suffixes in their templates (e.g., a base model). 