### PR TITLE
feat: allow for empty tokenizer chat template

### DIFF
--- a/nanogcg/gcg.py
+++ b/nanogcg/gcg.py
@@ -185,6 +185,10 @@ class GCG:
 
         if model.device == torch.device("cpu"):
             logger.warning("Model is on the CPU. Use a hardware accelerator for faster optimization.")
+
+        if not tokenizer.chat_template:
+            logger.warning("Tokenizer does not have a chat template. Assuming base model and setting chat template to empty.")
+            tokenizer.chat_template = "{% for message in messages %}{{ message['content'] }}{% endfor %}"
     
     def run(
         self,


### PR DESCRIPTION
As discussed in #14 , allow for models which do not have a default chat template set. This sets the template to just the text in the message.