### PR TITLE
fix: sort when calling add

### DIFF
--- a/nanogcg/gcg.py
+++ b/nanogcg/gcg.py
@@ -62,9 +62,9 @@ class AttackBuffer:
 
         if len(self.buffer) < self.size:
             self.buffer.append((loss, optim_ids))
-            return
+        else:
+            self.buffer[-1] = (loss, optim_ids)
 
-        self.buffer[-1] = (loss, optim_ids)
         self.buffer.sort(key=lambda x: x[0])
 
     def get_best_ids(self) -> Tensor:
@@ -359,6 +359,8 @@ class GCG:
         # Populate the buffer
         for i in range(true_buffer_size):
             buffer.add(init_buffer_losses[i], init_buffer_ids[[i]])
+        
+        buffer.log_buffer(tokenizer)
 
         logger.info("Initialized attack buffer.")
         


### PR DESCRIPTION
As mentioned in #15 problem1, The buffer doesn't sort until it's full.  I manage to fix it by sorting every time something is added. 

The buffer is logged upon initialization, enabling the user to observe the initial state.